### PR TITLE
Update description to note bootstrap functionality.

### DIFF
--- a/OfficialStatistics.md
+++ b/OfficialStatistics.md
@@ -262,7 +262,9 @@ R packages for this can be found.
 - `r pkg("svrep")` provides tools for creating, updating and
     analyzing survey replicate weights as an extension of `r pkg("survey")`.
     Non-response adjustments to both full-sample and replicate
-    weights can be applied.
+    weights can be applied. Bootstrap replicate weights can be 
+    created for a variety of sampling designs, including stratified multistage samples
+    and samples selected using systematic or unequal probability sampling.
     
 
 ### 5.2 Visualization


### PR DESCRIPTION
Hi Task View team,

This pull request adds an extra bit of text to the description of 'svrep', which now implements bootstrap methods for complex surveys. In case you're interested, the functionality is described in the following vignette:

https://bschneidr.github.io/svrep/articles/bootstrap-replicates.html

The text notes that the bootstrap methods are applicable to systematic sample and PPS designs, which is noteworthy because that is not the case for bootstrap methods implemented in the 'survey', 'surveysd', or 'surveybootstrap' packages (the latter of which has been removed from CRAN, at least temporarily).

Please let me know if you would like me to make additional edits to this pull request.

Thanks,

Ben
