### PR TITLE
Add subsection related to nonresponse, list more packages in weighting/calibration section

### DIFF
--- a/OfficialStatistics.md
+++ b/OfficialStatistics.md
@@ -153,6 +153,15 @@ be found on the CRAN task view on `r view("WebTechnologies")`.
     a calibrated bootstrap optimized for complex surveys and error
     estimation based on it.
 - `r pkg("inca")` performs calibration weighting with integer weights.
+- `r pkg("nrba")` provides functions for weight adjustments
+    to mitigate nonresponse bias, in particular `wt_class_adjust()` and
+    `rake_to_benchmarks()`. It also includes a diagnostic function
+    `t_test_of_weight_adjustment()` to compare estimates from different
+    stages of weight adjustments.
+- `r pkg("svrep")` includes a function for conducting
+    weighting class adjustments, `redistribute_weights()`.
+    It also includes functions `calibrate_to_sample()` and `calibrate_to_estimate()` which
+    implement sample-based calibration methods that account for sampling error in control totals.
 
 ### 4.2 Editing (including outlier detection)
 

--- a/OfficialStatistics.md
+++ b/OfficialStatistics.md
@@ -201,6 +201,24 @@ e.g. X13-ARIMA-SEATS developed by the US Census Bureau. In the CRAN
 Task View `r view("TimeSeries")` section seasonal adjustment,
 R packages for this can be found.
 
+### 4.5 Response Rates and Nonresponse Analysis
+
+- `r pkg("nrba")` facilitates nonresponse bias analysis (NRBA)
+    for survey data, potentially arising from complex sample designs.
+    The user can calculate response rates, model response propensities,
+    and assess how respondents differ from the full sample or from
+    external benchmark data. Also implements weighting adjustments
+    commonly used to mitigate nonresponse bias.
+
+- `r pkg("idcnrba")` implements an interactive Shiny application
+    that can be used to calculate response rates,
+    assess representativeness of survey respondents, and analyze
+    nonresponse bias. The application can export a formatted Excel report
+    to summarize analysis results.
+
+- `r pkg("outcomerate")` calculates outcome rates (response rates, 
+    refusal rates, etc.) using definitions standardized by AAPOR.
+
 ## 5 Analysis of Survey Data
 
 ### 5.1 Estimation and Variance Estimation


### PR DESCRIPTION
Hi Matthias,

This PR adds a small new subsection titled "response rates and nonresponse analysis", as a subsection of "Data Processing". The reason for implementing it as a subsection is because I didn't think it really fit into any of the other existing subsections: it's related to weighting and imputation, but is distinct enough that I didn't think it quite fit under either section. The reason for listing it under "Data Processing" is because it's typically the data producer that calculates the response rates and who conducts a nonresponse bias analysis.

A smaller, somewhat related change is that I listed a couple more packages under the weighting/calibration section. The addition of 'svrep' in particular is notable because it's the only package I'm aware of that implements sample-based calibration methods.