### PR TITLE
Add `reclin2` to the list of record linkage packages.

### DIFF
--- a/OfficialStatistics.md
+++ b/OfficialStatistics.md
@@ -116,6 +116,8 @@ The task view is split into several parts
 - `r pkg("PPRL")` implements privacy preserving record linkage, especially useful 
     when personal ID's cannot be used to link two data sets. This approach then
     protects the identity of persons.
+- `r pkg("reclin2")` provides functions to assist in performing 
+    probabilistic record linkage and deduplication.
 
 ### 3.2 Web Scraping
 


### PR DESCRIPTION
This short PR adds the 'reclin2' package for record linkage, from Jan van der Laan at Statistics Netherlands. Related to #24, this package is similar to 'reclin', which remains archived.