### PR TITLE
Add fishstat package

### DIFF
--- a/OfficialStatistics.md
+++ b/OfficialStatistics.md
@@ -362,6 +362,8 @@ amount of information loss.
     European Union.
 - `r pkg("ipumsr")` provides an easy way to import
     census, survey and geographic data provided by IPUMS.
+- `r pkg("fishstat")` provides the UN Food and Agricultural Organization (FAO)
+    FishStat global fisheries and aquaculture production data as R data frames.
 - `r pkg("FAOSTAT")` can be used to download data from the
     FAOSTAT database of the Food and Agricultural Organization (FAO) of
     the United Nations.


### PR DESCRIPTION
Hi, the new `fishstat` package provides UN (FAO) global fisheries and aquaculture production as R data frames. The current data are from 1950 to 2022, and I will update `fishstat` on CRAN whenever FAO releases a new version of their data annually. Every data frame comes with a cross-referenced help page and relevant examples.